### PR TITLE
bug: add z-index to syllabus; add space after colon; edit 2nd bullet

### DIFF
--- a/_includes/talent-accelerator/dta-syllabus.html
+++ b/_includes/talent-accelerator/dta-syllabus.html
@@ -1,5 +1,5 @@
 <!-- DTA Syllabus - START -->
-<section id="dta-syllabus">
+<section id="dta-syllabus" class="z-100">
     <div class="grid-container">
         <div class="grid-row flex-justify-center flex-align-center mobile:padding-y-15 tablet:padding-y-15 desktop-lg:padding-y-15">
             <div class="syllabus-text grid-col-12 tablet:grid-col-12 tablet-lg:grid-col-5">

--- a/_includes/talent-accelerator/timeline.html
+++ b/_includes/talent-accelerator/timeline.html
@@ -22,7 +22,7 @@
                     <h2 class="margin-top-0 margin-bottom-2 text-primary-darker text-center">Diffusion Talent Accelerator Phases</h2>
                 </div>
             </div>
-        <div class="grid-row card-gradient margin-bottom-5">
+        <div class="grid-row card-gradient margin-bottom-5 z-100">
             <div class="grid-col-12 tablet-lg:grid-col-fill margin-bottom-3 tablet-lg:margin-bottom-0 card-gradient__col">
                 <div class="usa-card card-gradient__card card-gradient--card-1">
                     <div class="usa-card__container">
@@ -35,8 +35,7 @@
                             Application and Priority Establishment
                             <ul>
                                 <li><u>January - March:</u> Open Applications</li>
-                                <li><u>February - March:</u> Application Review</li>
-                                <li><u>March - April:</u> Cohort Participation Selection</li>
+                                <li><u>March - April:</u> Application Review and Cohort Participation Selection</li>
                                 <li><u>April - July:</u> MOU Establishment</li>
                                 <li><u>June - September:</u> DTA Specialist Recruitement and Prioroity Identification</li>
                             </ul>

--- a/_site/assets/js/mustache-fellows-render.js
+++ b/_site/assets/js/mustache-fellows-render.js
@@ -191,8 +191,8 @@ currentData.data[0].forEach(current => $('.owl-carousel.current--fellows').appen
 + "<img src='" + current.img + "'alt='" + current.alt + "' />" + "</div>" + "</div>" 
 + "<div class='usa-card__body'>" 
 + "<h2 class='margin-bottom-0 h3'>" + current.alt + "</h2>" 
-// + "<h3 class='margin-y-0 h4'>" + current.title + "</h3>" 
-+ "<p class='office_title margin-bottom-0'>" + current.office_title + "</p>" 
-+ "<p class='project'><strong>Capstone Project:</strong>" + current.project + "</p>" 
++ "<h3 class='margin-y-0 h4'>" + current.title + "</h3>" 
+// + "<p class='office_title margin-bottom-0'>" + current.office_title + "</p>" 
++ "<p class='project'><strong>Capstone Project:</strong> " + current.project + "</p>" 
 + "<p class='bio'>" + current.bio + "</p>" 
 + "</div>" + "</div>"));

--- a/_site/diffusion-talent-accelerator/index.html
+++ b/_site/diffusion-talent-accelerator/index.html
@@ -341,7 +341,7 @@
     </div>    
 </section>
     <!-- DTA Syllabus - START -->
-<section id="dta-syllabus">
+<section id="dta-syllabus" class="z-100">
     <div class="grid-container">
         <div class="grid-row flex-justify-center flex-align-center mobile:padding-y-15 tablet:padding-y-15 desktop-lg:padding-y-15">
             <div class="syllabus-text grid-col-12 tablet:grid-col-12 tablet-lg:grid-col-5">
@@ -380,7 +380,7 @@
                     <h2 class="margin-top-0 margin-bottom-2 text-primary-darker text-center">Diffusion Talent Accelerator Phases</h2>
                 </div>
             </div>
-        <div class="grid-row card-gradient margin-bottom-5">
+        <div class="grid-row card-gradient margin-bottom-5 z-100">
             <div class="grid-col-12 tablet-lg:grid-col-fill margin-bottom-3 tablet-lg:margin-bottom-0 card-gradient__col">
                 <div class="usa-card card-gradient__card card-gradient--card-1">
                     <div class="usa-card__container">
@@ -393,8 +393,7 @@
                             Application and Priority Establishment
                             <ul>
                                 <li><u>January - March:</u> Open Applications</li>
-                                <li><u>February - March:</u> Application Review</li>
-                                <li><u>March - April:</u> Cohort Participation Selection</li>
+                                <li><u>March - April:</u> Application Review and Cohort Participation Selection</li>
                                 <li><u>April - July:</u> MOU Establishment</li>
                                 <li><u>June - September:</u> DTA Specialist Recruitement and Prioroity Identification</li>
                             </ul>

--- a/assets/js/mustache-fellows-render.js
+++ b/assets/js/mustache-fellows-render.js
@@ -191,8 +191,8 @@ currentData.data[0].forEach(current => $('.owl-carousel.current--fellows').appen
 + "<img src='" + current.img + "'alt='" + current.alt + "' />" + "</div>" + "</div>" 
 + "<div class='usa-card__body'>" 
 + "<h2 class='margin-bottom-0 h3'>" + current.alt + "</h2>" 
-// + "<h3 class='margin-y-0 h4'>" + current.title + "</h3>" 
-+ "<p class='office_title margin-bottom-0'>" + current.office_title + "</p>" 
-+ "<p class='project'><strong>Capstone Project:</strong>" + current.project + "</p>" 
++ "<h3 class='margin-y-0 h4'>" + current.title + "</h3>" 
+// + "<p class='office_title margin-bottom-0'>" + current.office_title + "</p>" 
++ "<p class='project'><strong>Capstone Project:</strong> " + current.project + "</p>" 
 + "<p class='bio'>" + current.bio + "</p>" 
 + "</div>" + "</div>"));


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Bug Fix
- [ ] Hot Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Add z-index to allow PDF download that are blocked by svg's
Text edit on 2nd bullet, 1st col: 
Add space after "Capstone Project:"

## Related Tickets & Documents
- Monday Task #6158463071
- https://blackberg-group.monday.com/boards/1931719392/pulses/6158463071

## QA Instructions, Screenshots, Recordings
Edits only to DTA section of DoE
Confirm that you can download DTA Syllabus PDF
Background SVG's above/below Syllabus visible on desktop and above screen sizes 

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [Google Lighthouse](https://developer.chrome.com/docs/lighthouse/overview) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?


## Are there any post deployment tasks we need to perform?
- Add GA code on production
- Proper meta tags utilized 

## Changed Files in this Pull Request ##
- _includes/talent-accelerator/dta-syllabus.html
 - _includes/talent-accelerator/timeline.html
 - _site/assets/js/mustache-fellows-render.js
 - _site/diffusion-talent-accelerator/index.html
 - assets/js/mustache-fellows-render.js